### PR TITLE
add github pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+# Story
+
+Refs
+
+- #issuenumber
+
+# Expected Behavior Before Changes
+
+# Expected Behavior After Changes
+
+# Screenshots / Video
+
+<details>
+<summary></summary>
+
+</details>
+
+# Notes


### PR DESCRIPTION
refs: https://github.com/scientist-softserv/dev-ops/issues/632

Now that we've moved to GitHub, we are working to maintain consistency across our repos' tickets and PRs. AMS already has 3 of their own issue templates, so we left those alone. They don't have PR templates, though, so we added our version. If AMS doesn't want to keep the PR template, it can easily be removed.